### PR TITLE
Updated program name in usageHead

### DIFF
--- a/tir.go
+++ b/tir.go
@@ -17,7 +17,7 @@ const Version string = "0.2.1"
 const usageHead string = `
 Usage:
 
-  tmg [options] <image>
+  tir [options] <image>
 
 Description:
 


### PR DESCRIPTION
The program name was formerly printed as `tmg`. As it is `tir`, this PR changes it accordingly.

Cheers
